### PR TITLE
Added Portrait option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,10 @@ if(NOT Planner_PDF_Left_Handed)
   set(Planner_PDF_Left_Handed 0)
 endif()
 
+if(NOT Planner_PDF_Portrait)
+  set(Planner_PDF_Portrait 0)
+endif()
+
 set(EXEC_NAME Planner_PDF)
 
 # set the project name

--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ The `make create` command will generate a file called planner.pdf in the build d
     COMPRESSED_FILE                        | planner_compressed  | The filename of a compressed version of the file
     Planner_PDF_Start_Day                  | 0                   | This allows moving the start day of the month view to a day other than Sunday
                                            |                     | 0 : Sun, 1 : Mon, 2 : Tue, 3 : Wed, 4 : Thu, 5 : Fri, 6 : Sat
+    Planner_PDF_Portrait                   | 0                   | 0 : Landscape, 1 : Portrait
+
 
 There is a make target called `make compress` which will us ghostscript to try to reduce the filesize. For the 5 year planner it can bring the size down from ~43mb to ~19mb.
 

--- a/include/planner_base.hpp
+++ b/include/planner_base.hpp
@@ -97,12 +97,15 @@ protected:
   /*! Whether it shouold be left handed orientation */
   bool _is_left_handed;
 
+  /*! Whether it should be portrait / landscape orientation */
+  bool _is_portrait;
+
 public:
   PlannerBase()
       : _id(0), _note_section_percentage(0.5), _page_title("Base"),
         _page_title_font_size(45), _note_title_font_size(35),
         _grid_string("GridBase"), _margin_width(Remarkable_margin_width_px), _is_left_handed(false),
-        _page_width(Remarkable_width_px), _page_height(Remarkable_height_px)
+        _page_width(Remarkable_width_px), _page_height(Remarkable_height_px), _is_portrait(false)
   {
     _margin_left = _margin_width;
     _margin_right = _page_width - _margin_width;
@@ -112,7 +115,7 @@ public:
       : _id(0), _note_section_percentage(0.5), _page_title("Base"),
         _page_title_font_size(45), _note_title_font_size(35),
         _grid_string(grid_string), _margin_width((Remarkable_margin_width_px)), _is_left_handed(is_left_handed),
-        _page_width(Remarkable_width_px), _page_height(Remarkable_height_px)
+        _page_width(Remarkable_width_px), _page_height(Remarkable_height_px), _is_portrait(false)
   {
     _margin_left = _margin_width;
     _margin_right = _page_width - _margin_width;
@@ -137,15 +140,19 @@ public:
                         HPDF_REAL x_stop,
                         HPDF_REAL y_stop) {
 
-    for (HPDF_REAL x = x_start; x < x_stop; x = x + dot_spacing_x) {
+//    for (HPDF_REAL x = x_start; x < x_stop; x = x + dot_spacing_x) {
+      HPDF_REAL x = x_start ;
+      const HPDF_UINT16 DASH_MODE1[] = {2, HPDF_UINT16(dot_spacing_x)};
+
       for (HPDF_REAL y = y_start; y < y_stop; y = y + dot_spacing_y) {
         HPDF_Page_SetLineWidth(page, 2);
-        // HPDF_Page_MoveTo(page, x, page_height - y);
-        // HPDF_Page_LineTo(page, x + 1, page_height - y + 1);
+        HPDF_Page_SetDash(page, DASH_MODE1, 2, 0);
+        HPDF_Page_MoveTo(page, x, page_height - y);
+        HPDF_Page_LineTo(page, x_stop, page_height - y);
         HPDF_Page_Rectangle(page, x, page_height - y, 1, 1);
         HPDF_Page_Stroke(page);
       }
-    }
+//    }
   }
 
   void FillAreaWithLines(HPDF_Page& page,

--- a/include/planner_days.hpp
+++ b/include/planner_days.hpp
@@ -58,7 +58,8 @@ public:
              std::string page_title,
              std::string grid_string,
              HPDF_REAL margin,
-             bool is_left_handed
+             bool is_left_handed,
+             bool is_portrait
              )
       : _day((date::year_month_day){
             (date::year)year, (date::month)month, (date::day)day}) {
@@ -69,6 +70,7 @@ public:
     _parent = parent_month;
     _margin_width = margin;
     _is_left_handed = is_left_handed;
+    _is_portrait = is_portrait;
   }
 
   void CreateTasksSection(HPDF_Doc& doc) {

--- a/include/planner_main.hpp
+++ b/include/planner_main.hpp
@@ -58,7 +58,8 @@ public:
               HPDF_REAL width,
               HPDF_REAL margin,
               short first_day_of_week,
-              bool is_left_handed
+              bool is_left_handed,
+              bool is_portrait
               )
       : _base_date((date::year)year, (date::month)1, (date::day)1),
         _filename(filename), _num_years(num_years) {
@@ -68,6 +69,7 @@ public:
     _margin_width = margin;
     _first_day_of_week = first_day_of_week;
     _is_left_handed = is_left_handed;
+    _is_portrait = is_portrait;
   }
 
   static void
@@ -160,7 +162,7 @@ public:
     for (size_t loop_index = 0; loop_index < _num_years; loop_index++) {
       date::year next_year = _base_date.year() + (date::years)loop_index;
       _years.push_back(std::make_shared<PlannerYear>(PlannerYear(
-          next_year, shared_from_this(), _page_height, _page_width, _margin_width, _first_day_of_week, _is_left_handed)));
+          next_year, shared_from_this(), _page_height, _page_width, _margin_width, _first_day_of_week, _is_left_handed, _is_portrait)));
       if (loop_index != 0) {
         _years.back()->SetLeft(_years[loop_index - 1]);
         _years[loop_index - 1]->SetRight(_years.back());

--- a/include/planner_month.hpp
+++ b/include/planner_month.hpp
@@ -59,17 +59,20 @@ public:
                HPDF_REAL width,
                HPDF_REAL margin,
                short first_day_of_week,
-               bool is_left_handed
+               bool is_left_handed,
+               bool is_portrait
                )
       : _month(month) {
     _page_title = format("%b %Y", _month);
     _grid_string = format("%b", _month);
     _page_height = height;
     _page_width = width;
-    _note_section_percentage = 0.25;
+//    _note_section_percentage = 0.25;
+    _note_section_percentage = is_portrait?0.085:0.25;
     _parent = parent_year;
     _first_day_of_week = first_day_of_week;
     _is_left_handed = is_left_handed;
+    _is_portrait = is_portrait;
   }
 
   std::vector<std::shared_ptr<PlannerBase>>& GetDays() { return _days; }
@@ -99,7 +102,8 @@ public:
                                                   day_page_title,
                                                   day_grid_title,
                                                   _margin_width,
-                                                  _is_left_handed
+                                                  _is_left_handed,
+                                                  _is_portrait
                                                   )));
 
       std::shared_ptr<PlannerBase> prev_day;

--- a/include/planner_pdf_config.h.in
+++ b/include/planner_pdf_config.h.in
@@ -35,3 +35,5 @@
 
 #define Planner_PDF_Start_Day @Planner_PDF_Start_Day@
 #define Planner_PDF_Left_Handed @Planner_PDF_Left_Handed@
+
+#define Planner_PDF_Portrait @Planner_PDF_Portrait@

--- a/include/planner_year.hpp
+++ b/include/planner_year.hpp
@@ -56,18 +56,21 @@ public:
               HPDF_REAL width,
               HPDF_REAL margin,
               short first_day_of_week,
-              bool is_left_handed
+              bool is_left_handed,
+              bool is_portrait
               )
       : _year(year) {
     _page_title = format("%Y", _year);
     _grid_string = format("%Y", _year);
     _page_height = height;
     _page_width = width;
-    _note_section_percentage = 0.25;
+//    _note_section_percentage = 0.25;
+    _note_section_percentage = is_portrait?0.085:0.25;
     _parent = parent_main;
     _margin_width = margin;
     _first_day_of_week = first_day_of_week;
     _is_left_handed = is_left_handed;
+    _is_portrait = is_portrait;
   }
 
   PlannerYear(short year) : _year((date::year)year) {}
@@ -105,8 +108,8 @@ public:
                section_y_start + 5,
                section_x_stop - 15,
                section_y_stop - 45,
-               3,
-               4,
+               _is_portrait?4:3,
+               _is_portrait?3:4,
                _months,
                true,
                0,
@@ -144,7 +147,8 @@ public:
                        _page_width,
                        _margin_width,
                        _first_day_of_week,
-                       _is_left_handed
+                       _is_left_handed,
+                       _is_portrait
                        )));
 
       std::shared_ptr<PlannerBase> prev_month;

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -46,6 +46,8 @@ enum PlannerTypes {
 
 const std::int64_t Remarkable_width_px = 1872;
 const std::int64_t Remarkable_height_px = 1404;
+//const std::int64_t Remarkable_width_px = 1404;
+//const std::int64_t Remarkable_height_px = 1872;
 const std::int64_t Remarkable_margin_width_px = 120;
 HPDF_REAL GetCenteredTextYPosition(HPDF_Page& page,
                                    std::string text,

--- a/src/planner_pdf.cpp
+++ b/src/planner_pdf.cpp
@@ -110,11 +110,12 @@ int main(int argc, char* argv[]) {
   auto Test = std::make_shared<PlannerMain>(PlannerMain(start_year,
                                                         filename,
                                                         num_years,
-                                                        Remarkable_height_px,
-                                                        Remarkable_width_px,
+                                                        Planner_PDF_Portrait?Remarkable_width_px:Remarkable_height_px,
+                                                        Planner_PDF_Portrait?Remarkable_height_px:Remarkable_width_px,
                                                         Remarkable_margin_width_px,
                                                         Planner_PDF_Start_Day,
-                                                        Planner_PDF_Left_Handed
+                                                        Planner_PDF_Left_Handed,
+                                                        Planner_PDF_Portrait
         ));
   Test->CreateDocument();
   Test->Build();


### PR DESCRIPTION
I like your work, I also need to have the Planner in Portrait mode, so my fork.
- Added an option during cmake to switch from Landscape to Portrait:  -DPlanner_PDF_Portrait=0/1
- Year and Month Pages loose the Notes area to keep aspect ratio,
- BUG: Notes title is still there and miscentered
- Dotted area in Task pane is now done using a dashed line, greatly reduces PDF size.
- TODO: add the Week and Quarters view. 
- TODO: use bigger/bold fonts when possible:in Titles, year number in Year page and days in Month page.
- TODO: Hourly planner in Day page instead of Tasks